### PR TITLE
Update homeslider.js

### DIFF
--- a/js/homeslider.js
+++ b/js/homeslider.js
@@ -36,7 +36,7 @@ $(document).ready(function(){
         homeslider_width = 779;
 
 
-	if (!!$.prototype.bxSlider)
+	if (!$.prototype.bxSlider)
 		$('#homeslider').bxSlider({
 			useCSS: false,
 			maxSlides: 1,


### PR DESCRIPTION
removed double exclamation mark. this lead to a bug in my custome theme. the homeslider got randomly invisible, cause bxslider hasn't been proper instantiated in this way.